### PR TITLE
Changed 'my RG' to 'myRG' in src/rgged.cc, to prevent for follolowing…

### DIFF
--- a/src/rgged.cc
+++ b/src/rgged.cc
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
 	SamProgram rgged; rgged.CommandLine = args; rgged.ID="rgged";
 	head.Programs.Add(rgged); 
 	SamReadGroup myRG; myRG.ID=ID; if(SM=="") { SM=ID; myRG.Sample=SM;} 
-	if(SM!="") { my RG.Sample=SM;}
+	if(SM!="") { myRG.Sample=SM;}
 	if(LB!="") { myRG.Library=LB;} 
 	if(PL!="") { myRG.SequencingTechnology=PL;}
 	SamReadGroupDictionary rg; rg.Add(myRG);


### PR DESCRIPTION
```Scanning dependencies of target rgged
[ 97%] Building CXX object src/CMakeFiles/rgged.dir/rgged.cc.o
/packages/rgged/src/rgged.cc: In function ‘int main(int, char**)’:
/packages/rgged/src/rgged.cc:51:15: error: ‘my’ was not declared in this scope
  if(SM!="") { my RG.Sample=SM;}
               ^
/packages/rgged/src/rgged.cc:51:18: error: expected ‘;’ before ‘RG’
  if(SM!="") { my RG.Sample=SM;}
                  ^
make[2]: *** [src/CMakeFiles/rgged.dir/rgged.cc.o] Error 1
make[1]: *** [src/CMakeFiles/rgged.dir/all] Error 2
make: *** [all] Error 2
```

The above error occurs if this small typo is not fixed.
"my RG" was changed to "myRG" to prevent this error during the compilation step.